### PR TITLE
[WIS-7452] deprecation extension

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: ['push']
+on:
+  push:
+    branches: [ 'master', 'release-0-8', 'release-0-9', 'release-0-10' ]
+  pull_request:
+    branches: ['**']
 
 jobs:
   tests:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ 'master', 'release-0-8', 'release-0-9', 'release-0-10' ]
+    branches: ['**']
   pull_request:
     branches: ['**']
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,12 +32,11 @@ jobs:
         rails:
           - 6.1.1
           - 6.0.3.4
-          - 5.2.4.4
-          - 5.1.7
         database_url:
           - postgresql://postgres:password@localhost:5432/test
           - sqlite3:test_db
         exclude:
+          - database_url: mysql2://root:root@127.0.0.1:3306/test
           - ruby: 3.0.0
             rails: 6.0.3.4
           - ruby: 3.0.0

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: ['**']
-  pull_request:
-    branches: ['**']
+on: ['push']
 
 jobs:
   tests:

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -42,7 +42,7 @@ module JSONAPI
                 :default_exclude_links,
                 :use_related_resource_records_for_joins
     
-    attr_accessor :resource_deprecations
+    attr_accessor :resource_deprecations, :format_deprecation_logger_context
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -169,6 +169,9 @@ module JSONAPI
 
       # Enable/Disable the resource deprecation feature.
       self.resource_deprecations = false
+
+      #
+      self.format_deprecation_logger_context = ->(context) {'context message not configured'}
     end
 
     def cache_formatters=(bool)
@@ -255,12 +258,8 @@ module JSONAPI
       @default_allow_include_to_many = allow_include
     end
 
-    def format_deprecation_logger_context(context)
-      'context message not configured'
-    end
-
     def format_deprecation_logger_message(identity:, type:, name:, message:, context:)
-      context_message = format_deprecation_logger_context(context)
+      context_message = format_deprecation_logger_context.call(context)
 
       "JSONAPI::Resources::Deprecation identity=#{identity} type=#{type} name=#{name} message=#{message} context=#{context_message}"
     end

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -41,6 +41,8 @@ module JSONAPI
                 :resource_cache_usage_report_function,
                 :default_exclude_links,
                 :use_related_resource_records_for_joins
+    
+    attr_accessor :resource_deprecations
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -164,6 +166,9 @@ module JSONAPI
       # permission scopes. It can be overridden explicitly per relationship. Furthermore, specifying a `relation_name`
       # on a relationship will cause this setting to be ignored.
       self.use_related_resource_records_for_joins = true
+
+      # Enable/Disable the resource deprecation feature.
+      self.resource_deprecations = false
     end
 
     def cache_formatters=(bool)
@@ -248,6 +253,22 @@ module JSONAPI
       ActiveSupport::Deprecation.warn('`allow_include` has been replaced by `default_allow_include_to_one` and `default_allow_include_to_many` options.')
       @default_allow_include_to_one = allow_include
       @default_allow_include_to_many = allow_include
+    end
+
+    def format_deprecation_logger_context(context)
+      'context message not configured'
+    end
+
+    def format_deprecation_logger_message(identity:, type:, name:, message:, context:)
+      context_message = format_deprecation_logger_context(context)
+
+      "JSONAPI::Resources::Deprecation identity=#{identity} type=#{type} name=#{name} message=#{message} context=#{context_message}"
+    end
+
+    def deprecation_logger(identity:, type:, name:, message:, context:)
+      message = format_deprecation_logger_message(identity: identity, type: type, name: name, message: message, context: context)
+
+      Rails.logger.warn(message)
     end
 
     attr_writer :allow_sort, :allow_filter, :default_allow_include_to_one, :default_allow_include_to_many

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -4848,6 +4848,15 @@ class Api::WithDeprecationPolicy::PostsControllerTest < ActionController::TestCa
     assert json_response['data']['relationships']['writer'].has_key?('data'), 'data should exist for deprecated relationship'
   end
 
+  def test_has_many_relationship_includes_deprecated_meta
+    assert_cacheable_get :index, params: {include: 'author.books'}
+
+    assert_response :success
+
+    json_response['included'].each do |author|
+      assert_equal 'we only support authors of comments and posts; books are dead.', author['meta']['deprecations']['relationships']['books']
+    end
+  end
 
   def test_includes_deprecated_relationship_logs_warning
     with_logger_introspection do |logger_output|

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -4853,9 +4853,16 @@ class Api::WithDeprecationPolicy::PostsControllerTest < ActionController::TestCa
 
     assert_response :success
 
+    tested = 0
+
     json_response['included'].each do |author|
+      next unless author['type'] == 'authors'
+      next unless author['relationships']['books']['data'] # deprecated meta only included with loaded relationships, not with empty linkage data.
       assert_equal 'we only support authors of comments and posts; books are dead.', author['meta']['deprecations']['relationships']['books']
+      tested += 1
     end
+
+    assert_equal 2, tested
   end
 
   def test_includes_deprecated_relationship_logs_warning

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1197,6 +1197,43 @@ module Api
       end
     end
   end
+
+  module WithDeprecationPolicy
+    class AuthorsController < JSONAPI::ResourceController
+    end
+
+    class BooksController < JSONAPI::ResourceController
+    end
+
+    class PostsController < JSONAPI::ResourceController
+    end
+
+    class TagsController < JSONAPI::ResourceController
+    end
+
+    class AuthorResource < JSONAPI::Resource
+      model_name 'Person'
+      attributes :name
+    
+      has_many :books, inverse_relationship: :authors
+    end
+
+    class PostResource < JSONAPI::Resource
+      attribute :title
+      attribute :headline, delegate: :title, deprecated: 'Please use title.'
+      attribute :body
+    
+      has_one :author
+      has_one :writer, class_name: 'Author', deprecated: 'Please use author.'
+    end
+
+    class BookResource < JSONAPI::Resource
+      attribute :title
+    
+      has_many :authors, class_name: 'Author', inverse_relationship: :books
+    end
+
+  end
 end
 
 module Api

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1215,7 +1215,8 @@ module Api
       model_name 'Person'
       attributes :name
     
-      has_many :books, inverse_relationship: :authors
+      has_many :books, inverse_relationship: :authors, deprecated: 'we only support authors of comments and posts; books are dead.'
+      has_many :posts, inverse_relationship: :author
     end
 
     class PostResource < JSONAPI::Resource

--- a/test/helpers/configuration_helpers.rb
+++ b/test/helpers/configuration_helpers.rb
@@ -57,5 +57,16 @@ module Helpers
 
       return results
     end
+
+    def with_logger_introspection(&block)
+      orig_logger = Rails.logger.dup
+      @logger_output = StringIO.new
+      begin
+        Rails.logger = ActiveSupport::Logger.new(@logger_output)
+        block.call(@logger_output)
+      ensure
+        Rails.logger = orig_logger
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -305,6 +305,12 @@ TestApp.routes.draw do
     jsonapi_resources :things
     jsonapi_resources :users
 
+    namespace :with_deprecation_policy do
+      jsonapi_resources :authors
+      jsonapi_resources :books
+      jsonapi_resources :posts
+    end
+
     namespace :v1 do
       jsonapi_resources :people
       jsonapi_resources :comments


### PR DESCRIPTION
This PR adds the deprecation functionality described [here](https://wisdomhealth.atlassian.net/wiki/spaces/EN/pages/2490105884/Wisdom+API+Deprecation+Policy) to the v0.10 version of jsonapi_resources gem. 

### Usage

**Resource deprecated option**
Any resource attribute or relationship may be marked as deprecated using the deprecated option. 

``` Ruby
class HealthTestResultResource < JSONAPI::Resource
  attribute :result_female, deprecated: 'health test results are calculated using the pet sex, please use `result`'
  has_many :very_bad_decisions, deprecated: 'was needed to facilitate a report builder and has since been replaced by a new good_decisions endpoint.'
end
```
The depricated option does not remove the attribute or relationship it only adds the following behavior.

Logs a warning every time the attribute or relationship is serialized.

Adds a key to the meta.deprecations response object that clients may use to log and fix warnings.

**Configuration**

Using the JSONAPIResources initializer.

```Ruby
JSONAPI.configure do |config|
  config.resource_deprecations = true

  # Configure how the context should be logged.
  config.format_deprecation_logger_context = ->(context) { 
    "#{context[:current_user]&.class} #{context[:current_user].try(:id)}"
  }
end
```

**Example Payload**
![Screenshot 2024-10-25 at 9 06 49 AM](https://github.com/user-attachments/assets/7925c89b-d4d9-48a7-bfa3-d5881e100730)

**Example logging statement**
![Screenshot 2024-10-25 at 9 08 58 AM](https://github.com/user-attachments/assets/24f1f6d4-a557-4ed6-8f92-9e309d439cb8)




